### PR TITLE
cmake: Set minimum required version to 3.5 for CMake 4+ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 project (mrp C)
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.5)
 
 ## libnl ################################################
 find_path(LibNL_INCLUDE_DIR netlink/netlink.h


### PR DESCRIPTION
Fixes:
```
CMake Error at CMakeLists.txt:6 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.

-- Configuring incomplete, errors occurred!
```
